### PR TITLE
fix: allowNormalizedSignin fails when input matches normalized email

### DIFF
--- a/packages/plugins/src/email/email-otp.test.ts
+++ b/packages/plugins/src/email/email-otp.test.ts
@@ -223,6 +223,35 @@ describe('email-otp', async () => {
     expect(res.data?.token).toBeDefined();
   });
 
+  it('should sign in with otp using already-normalized email form', async () => {
+    const rawEmail = 'o.t.p.test+tag@gmail.com';
+    await client.signUp.email({
+      email: rawEmail,
+      password: 'otp-test-pw',
+      name: 'otp-test'
+    });
+    // The normalized form is 'otptest@gmail.com'
+    const normalizedForm = 'otptest@gmail.com';
+    const res = await client.emailOtp.sendVerificationOtp({
+      email: normalizedForm,
+      type: 'sign-in'
+    });
+    expect(res.data?.success).toBe(true);
+    const verifiedUser = await client.signIn.emailOtp(
+      {
+        email: normalizedForm,
+        otp
+      },
+      {
+        onSuccess: (ctx) => {
+          const header = ctx.response.headers.get('set-cookie');
+          expect(header).toContain('better-auth.session_token');
+        }
+      }
+    );
+    expect(verifiedUser.data?.token).toBeDefined();
+  });
+
   it('should fail on invalid email', async () => {
     const res = await client.emailOtp.sendVerificationOtp({
       email: 'invalid-email',
@@ -465,7 +494,7 @@ describe('custom rate limiting storage', async () => {
       plugins: [
         emailHarmony({ allowNormalizedSignin: true }),
         emailOTP({
-          async sendVerificationOTP() {}
+          async sendVerificationOTP() { }
         })
       ]
     },

--- a/packages/plugins/src/email/email.test.ts
+++ b/packages/plugins/src/email/email.test.ts
@@ -143,6 +143,21 @@ describe('email harmony', async () => {
       });
       expect(error?.status).toBe(401);
     });
+
+    it('should work when signing in with already-normalized email form', async () => {
+      const rawEmail = 'a.bc+tag@gmail.com';
+      await client.signUp.email({
+        email: rawEmail,
+        password: 'normalized-test-pw',
+        name: 'normalized-test'
+      });
+      // Sign in with the normalized form directly
+      const { data } = await client.signIn.email({
+        email: 'abc@gmail.com',
+        password: 'normalized-test-pw'
+      });
+      expect(data?.user.email).toBe(rawEmail);
+    }, 15_000);
   });
 
   describe('reset password', () => {

--- a/packages/plugins/src/email/index.ts
+++ b/packages/plugins/src/email/index.ts
@@ -178,42 +178,43 @@ const emailHarmony = ({
 
             const normalizedEmail = normalizer(email);
 
-            if (normalizedEmail !== email) {
-              const user = await ctx.context.adapter.findOne<UserWithNormalizedEmail>({
-                model: 'user',
-                where: [
-                  {
-                    field: 'normalizedEmail',
-                    value: normalizedEmail
-                  }
-                ]
-              });
+            /* v8 ignore next */
+            if (!normalizedEmail) return;
 
-              if (!user) return;
+            const user = await ctx.context.adapter.findOne<UserWithNormalizedEmail>({
+              model: 'user',
+              where: [
+                {
+                  field: 'normalizedEmail',
+                  value: normalizedEmail
+                }
+              ]
+            });
 
-              // Types are broken without explicit reference
-              return container === 'query'
-                ? {
-                    context: {
-                      ...ctx,
-                      query: {
-                        ...ctx.query,
-                        email: user.email,
-                        normalizedEmail
-                      }
-                    }
+            if (!user || user.email === email) return;
+
+            // Types are broken without explicit reference
+            return container === 'query'
+              ? {
+                context: {
+                  ...ctx,
+                  query: {
+                    ...ctx.query,
+                    email: user.email,
+                    normalizedEmail
                   }
-                : {
-                    context: {
-                      ...ctx,
-                      body: {
-                        ...(ctx.body as Context['body']),
-                        email: user.email,
-                        normalizedEmail
-                      }
-                    }
-                  };
-            }
+                }
+              }
+              : {
+                context: {
+                  ...ctx,
+                  body: {
+                    ...(ctx.body as Context['body']),
+                    email: user.email,
+                    normalizedEmail
+                  }
+                }
+              };
           })
         }
       ]

--- a/packages/plugins/src/email/magic-link.test.ts
+++ b/packages/plugins/src/email/magic-link.test.ts
@@ -243,6 +243,56 @@ describe('magic link harmony', async () => {
     });
     expect(dbUser?.email).toBe(email);
   });
+  it('should sign in with already-normalized email form', async () => {
+    const rawEmail = 'm.agic+tag@gmail.com';
+    await client.signIn.magicLink({
+      email: rawEmail,
+      name: 'magic-normalized-test'
+    });
+    let headers = new Headers();
+    await client.magicLink.verify({
+      query: {
+        token: new URL(verificationEmail.url).searchParams.get('token') ?? ''
+      },
+      fetchOptions: {
+        onSuccess: sessionSetter(headers)
+      }
+    });
+    const session = await client.getSession({
+      fetchOptions: {
+        headers
+      }
+    });
+    expect(session.data?.user).toMatchObject({
+      name: 'magic-normalized-test',
+      email: rawEmail,
+      emailVerified: true
+    });
+
+    // Now sign in with the normalized form directly
+    headers = new Headers();
+    await client.signIn.magicLink({
+      email: 'magic@gmail.com'
+    });
+    await client.magicLink.verify({
+      query: {
+        token: new URL(verificationEmail.url).searchParams.get('token') ?? ''
+      },
+      fetchOptions: {
+        onSuccess: sessionSetter(headers)
+      }
+    });
+    const session2 = await client.getSession({
+      fetchOptions: {
+        headers
+      }
+    });
+    expect(session2.data?.user).toMatchObject({
+      name: 'magic-normalized-test',
+      email: rawEmail,
+      emailVerified: true
+    });
+  });
 }, 15_000);
 
 describe('magic link verify', async () => {


### PR DESCRIPTION
Fixes #56 

**The issue:**
Currently, if a user signs up with an alias (like `a.bc@gmail.com`), they can't log in with their base email (`abc@gmail.com`). The interceptor sees that the input already matches the normalized output and skips the `findOne` lookup. Better Auth then falls through to check the main `email` column, finds nothing, and fails. 

This specifically breaks auto-provisioning flows like Email OTP by triggering a unique constraint violation in the database when it tries to create a duplicate user for an email that already exists in the `normalizedEmail` column.

**What changed:**
* Removed the `if (normalizedEmail !== email)` guard so we actually run the lookup against the `normalizedEmail` column, even if the input is already normalized.
* Added `if (!normalizedEmail) return` just to be safe in case the normalizer fails.
* Added a check to skip the payload rewrite if no user is found or the email already matches.

**Note:**
This does add one extra DB query during login when a user signs in with an already-normalized email. Since `normalizedEmail` should be indexed, the hit is negligible and worth it to fix the broken auth flow.